### PR TITLE
Fixed SHOUTCast password

### DIFF
--- a/darkice/trunk/src/ConfigSection.cpp
+++ b/darkice/trunk/src/ConfigSection.cpp
@@ -8,19 +8,19 @@
    Version  : $Revision$
    Author   : $Author$
    Location : $HeadURL$
-   
+
    Copyright notice:
 
     This program is free software; you can redistribute it and/or
-    modify it under the terms of the GNU General Public License  
+    modify it under the terms of the GNU General Public License
     as published by the Free Software Foundation; either version 3
     of the License, or (at your option) any later version.
-   
+
     This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of 
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-   
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
@@ -81,8 +81,8 @@ ConfigSection :: add (   const char    * key,
 
     return res.second;
 }
-        
-        
+
+
 /*------------------------------------------------------------------------------
  *  Get a value for a key
  *----------------------------------------------------------------------------*/
@@ -112,7 +112,7 @@ ConfigSection :: getForSure (   const char    * key,
                                                         throw ( Exception )
 {
     const char      * value;
-    
+
     if ( !(value = get( key)) ) {
         throw Exception( __FILE__, __LINE__, key, message1, message2, code);
     }
@@ -132,12 +132,16 @@ ConfigSection :: addLine (  const char    * line )          throw ( Exception )
     }
 
     std::string::size_type  ix;
-    std::string             str( line);
+    std::string str( line);
+    std::string str2 ("password");
 
-    /* delete everything after the first # */
-    if ( (ix = str.find( '#')) != str.npos ) {
-        str.erase( ix);
+    if ( (ix = str.find(str2)) == str.npos ) {
+        /* delete everything after the first # */
+           if ( (ix = str.find( '#')) != str.npos ) {
+              str.erase( ix);
+            }
     }
+
     /* eat up all white space from the front */
     if ( (ix = str.find_first_not_of( WHITE_SPACE_STR)) != str.npos ) {
         str.erase( 0, ix);
@@ -170,4 +174,3 @@ ConfigSection :: addLine (  const char    * line )          throw ( Exception )
     /* now add the new key / value pair */
     return add( key.c_str(), value.c_str());
 }
-

--- a/darkice/trunk/src/DarkIce.cpp
+++ b/darkice/trunk/src/DarkIce.cpp
@@ -8,20 +8,20 @@
    Version  : $Revision$
    Author   : $Author$
    Location : $HeadURL$
-   
+
 
    Copyright notice:
 
     This program is free software; you can redistribute it and/or
-    modify it under the terms of the GNU General Public License  
+    modify it under the terms of the GNU General Public License
     as published by the Free Software Foundation; either version 3
     of the License, or (at your option) any later version.
-   
+
     This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of 
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-   
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
@@ -384,9 +384,9 @@ DarkIce :: configIceCast (  const Config      & config,
                              "unsupported stream format: ", str);
 
         }
-        
+
         // augment audio outs with a buffer when used from encoder
-        audioOut = new BufferedSink( audioOuts[u].server.get(), 
+        audioOut = new BufferedSink( audioOuts[u].server.get(),
                                                   bufferSize, 1);
 
 #ifdef HAVE_LAME_LIB
@@ -600,9 +600,9 @@ DarkIce :: configIceCast2 (  const Config      & config,
                                             isPublic,
                                             localDumpFile);
 
-        audioOut = new BufferedSink( audioOuts[u].server.get(), 
+        audioOut = new BufferedSink( audioOuts[u].server.get(),
                                      bufferSize, 1);
-        
+
         switch ( format ) {
             case IceCast2::mp3:
 #ifndef HAVE_LAME_LIB
@@ -792,7 +792,7 @@ DarkIce :: configShoutCast (    const Config      & config,
         FileSink                  * localDumpFile   = 0;
         bool                        fileAddDate     = false;
         const char                * fileDateFormat  = 0;
-        BufferedSink              * audioOut        = 0;
+        AudioEncoder              * encoder         = 0;
         int                         bufferSize      = 0;
 
         str         = cs->get( "sampleRate");
@@ -907,9 +907,7 @@ DarkIce :: configShoutCast (    const Config      & config,
                                              localDumpFile);
 
 
-        audioOut = new BufferedSink(audioOuts[u].socket.get(), bufferSize, 1);
-        audioOuts[u].encoder = new LameLibEncoder( 
-                                      audioOut,
+        encoder = new LameLibEncoder( audioOuts[u].server.get(),
                                       dsp.get(),
                                       bitrateMode,
                                       bitrate,
@@ -918,6 +916,7 @@ DarkIce :: configShoutCast (    const Config      & config,
                                       channel,
                                       lowpass,
                                       highpass );
+        audioOuts[u].encoder = new BufferedSink(encoder, bufferSize, dsp->getSampleSize());
 
         encConnector->attach( audioOuts[u].encoder.get());
 #endif // HAVE_LAME_LIB

--- a/darkice/trunk/src/DarkIceConfig.cpp
+++ b/darkice/trunk/src/DarkIceConfig.cpp
@@ -8,19 +8,19 @@
    Version  : $Revision$
    Author   : $Author$
    Location : $HeadURL$
-   
+
    Copyright notice:
 
     This program is free software; you can redistribute it and/or
-    modify it under the terms of the GNU General Public License  
+    modify it under the terms of the GNU General Public License
     as published by the Free Software Foundation; either version 3
     of the License, or (at your option) any later version.
-   
+
     This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of 
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-   
+
     You should have received a copy of the GNU General Public License
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
@@ -98,12 +98,16 @@ Config :: addLine (  const char    * line )          throw ( Exception )
     }
 
     std::string::size_type  ix;
-    std::string             str( line);
+    std::string str( line);
+    std::string str2 ("password");
 
-    /* delete everything after the first # */
-    if ( (ix = str.find( '#')) != str.npos ) {
-        str.erase( ix);
+    if ( (ix = str.find(str2)) == str.npos ) {
+       /* delete everything after the first # */
+       if ( (ix = str.find( '#')) != str.npos ) {
+          str.erase( ix);
+       }
     }
+
     /* eat up all white space from the front */
     if ( (ix = str.find_first_not_of( WHITE_SPACE_STR)) != str.npos ) {
         str.erase( 0, ix);
@@ -162,5 +166,3 @@ Config :: read (    std::istream  & is  )               throw ( Exception )
         addLine( line);
     }
 }
-
-    


### PR DESCRIPTION
- Darkice.cpp configShoutcast part is returned as it was on commit 710d2c26c4f9518d2f382673bf8b1829b9bdac3d . This makes DNAS 1.9.8 to work again.
- Added suggested code patches to code at DarkiceConfig.cpp and Config.cpp by Yahoosam on issue #121. So DNAS2.x now can read stream IDs along with password.