### PR TITLE
Update website for release 1.4

### DIFF
--- a/darkice/trunk/ChangeLog
+++ b/darkice/trunk/ChangeLog
@@ -1,5 +1,24 @@
-01-03-2020 Darkice 1.4 released
-    o Shoutcast and Icecast 2 connection issues fixed.
+03-01-2020 Darkice 1.4 released
+    Shoutcast and Icecast 2 connection issues fixed:
+
+    o Support newer HTTP versions in IceCast2 codebase.
+      PR #140 by LuK1337 <priv.luk@gmail.com>
+      - Some servers pretending to be IceCast 2 might return a version newer
+        than 1.0. The example server that happens to do
+        that is Cast ( https://github.com/innovate-technologies/Cast ).
+      - Replacing HTTP/1.0 with HTTP/1.[0-9] regex makes sure that we handle
+        newer versions properly instead of showing:
+        "Icecast2 - Unexpected response from server".
+    o Fixed SHOUTCast password.
+      PR #138 by Alejandro Olivan Alvarez <alejandro.olivan.alvarez@gmail.com>
+      - Darkice.cpp configShoutcast part is returned as it was on commit
+        710d2c26c4f9518d2f382673bf8b1829b9bdac3d. This makes DNAS 1.9.8
+        work again.
+      - Added suggested code patches to code at DarkiceConfig.cpp and
+        Config.cpp by Yahoosam on issue #121. So DNAS2.x now can get stream IDs.
+    o Added darksnow.desktop file.
+    o Cast float* in SRC lib calls to delete fpermissive compilation error.
+      PR #120 by belette <ouack23@yahoo.fr>
 
 04-08-2016 Darkice 1.3 released
     o Small bugs fixed by Nicolas Boulenguez <nicolas@debian.org>.
@@ -44,15 +63,15 @@
 	  thanks to Adrian Knoth again.
 
 09-05-2010 Darkice 1.0 released
-    o fixed a bug in BufferedSink.cpp that leads to some buffers 
+    o fixed a bug in BufferedSink.cpp that leads to some buffers
 	  being written twice, causing corruption of datastream,
 	  closes ticked #20
 	  thanks to Edwin van den Oetelaar <oetelaar.automatisering@gmail.com>
-    o implemented samplerate conversion for all codecs using libsamplerate, 
+    o implemented samplerate conversion for all codecs using libsamplerate,
 	  and keeping internal aflibConverter as fallback,
           thanks to Sergiy <piratfm@gmail.com>
     o bugfix: fix for alsa driver - closes ticked #8
-          thanks to Clemens Ladisch <clemens@ladisch.de> 
+          thanks to Clemens Ladisch <clemens@ladisch.de>
 
 14-11-2009 Darkice 0.20.1 released
     o added rc.darkice init script
@@ -61,8 +80,8 @@
 
 05-11-2009 Darkice 0.20 released
 
-    o new maintainer: Rafael Diniz <rafael@riseup.net>	
-    o added AAC HEv2 encoding support (branch darkice-aacp merged) through 
+    o new maintainer: Rafael Diniz <rafael@riseup.net>
+    o added AAC HEv2 encoding support (branch darkice-aacp merged) through
 	  libaacplus, http://tipok.org.ua/ru/node/17
 	  thanks to tipok <piratfm@gmail.com> and others for the contribution.
     o bugfix: the configure script recognizes Ogg Vorbis shared objects

--- a/website/trunk/htdocs/ChangeLog
+++ b/website/trunk/htdocs/ChangeLog
@@ -1,3 +1,25 @@
+03-01-2020 Darkice 1.4 released
+    Shoutcast and Icecast 2 connection issues fixed:
+
+    o Support newer HTTP versions in IceCast2 codebase.
+      PR #140 by LuK1337 <priv.luk@gmail.com>
+      - Some servers pretending to be IceCast 2 might return a version newer
+        than 1.0. The example server that happens to do
+        that is Cast ( https://github.com/innovate-technologies/Cast ).
+      - Replacing HTTP/1.0 with HTTP/1.[0-9] regex makes sure that we handle
+        newer versions properly instead of showing:
+        "Icecast2 - Unexpected response from server".
+    o Fixed SHOUTCast password.
+      PR #138 by Alejandro Olivan Alvarez <alejandro.olivan.alvarez@gmail.com>
+      - Darkice.cpp configShoutcast part is returned as it was on commit
+        710d2c26c4f9518d2f382673bf8b1829b9bdac3d. This makes DNAS 1.9.8
+        work again.
+      - Added suggested code patches to code at DarkiceConfig.cpp and
+        Config.cpp by Yahoosam on issue #121. So DNAS2.x now can get stream IDs.
+    o Added darksnow.desktop file.
+    o Cast float* in SRC lib calls to delete fpermissive compilation error.
+      PR #120 by belette <ouack23@yahoo.fr>
+
 04-08-2016 Darkice 1.3 released
     o Small bugs fixed by Nicolas Boulenguez <nicolas@debian.org>.
     o Bugs related to streaming to remote servers fixed. Patch by Kalle Kulonen
@@ -41,15 +63,15 @@
 	  thanks to Adrian Knoth again.
 
 09-05-2010 Darkice 1.0 released
-    o fixed a bug in BufferedSink.cpp that leads to some buffers 
+    o fixed a bug in BufferedSink.cpp that leads to some buffers
 	  being written twice, causing corruption of datastream,
 	  closes ticked #20
 	  thanks to Edwin van den Oetelaar <oetelaar.automatisering@gmail.com>
-    o implemented samplerate conversion for all codecs using libsamplerate, 
+    o implemented samplerate conversion for all codecs using libsamplerate,
 	  and keeping internal aflibConverter as fallback,
           thanks to Sergiy <piratfm@gmail.com>
     o bugfix: fix for alsa driver - closes ticked #8
-          thanks to Clemens Ladisch <clemens@ladisch.de> 
+          thanks to Clemens Ladisch <clemens@ladisch.de>
 
 14-11-2009 Darkice 0.20.1 released
     o added rc.darkice init script
@@ -58,8 +80,8 @@
 
 05-11-2009 Darkice 0.20 released
 
-    o new maintainer: Rafael Diniz <rafael@riseup.net>	
-    o added AAC HEv2 encoding support (branch darkice-aacp merged) through 
+    o new maintainer: Rafael Diniz <rafael@riseup.net>
+    o added AAC HEv2 encoding support (branch darkice-aacp merged) through
 	  libaacplus, http://tipok.org.ua/ru/node/17
 	  thanks to tipok <piratfm@gmail.com> and others for the contribution.
     o bugfix: the configure script recognizes Ogg Vorbis shared objects

--- a/website/trunk/htdocs/index.html
+++ b/website/trunk/htdocs/index.html
@@ -26,21 +26,21 @@ DarkIce is a live audio streamer. It records audio from an audio interface
 DarkIce can record from:
 <ul>
     <li><a href="http://www.opensound.com/">OSS</a> audio devices</li>
-    <li><a href="http://www.alsa-project.org/">ALSA</a> audio devices</li>
+    <li><a href="https://www.alsa-project.org/">ALSA</a> audio devices</li>
     <li>Solaris audio interface</li>
-    <li><a href="http://jackit.sourceforge.net/">Jack</a> sources</li>
+    <li><a href="https://jackaudio.org/">Jack</a> sources</li>
     <li>uLaw audio input through a serial interface</li>
     <li>CoreAudio (branch darkice-macosx)</li>
 </ul>
 <br>
 DarkIce can encode in the following formats:
 <ul>
-    <li>MP3 - using the <a href="http://www.mp3dev.org/mp3">lame</a>
+    <li>MP3 - using the <a href="https://lame.sourceforge.io/">lame</a>
         library</li>
     <li>MP2 - using the <a href="http://www.twolame.org/">twolame</a>
         library</li>
-    <li><a href="http://www.xiph.org/ogg/vorbis/">Ogg Vorbis</a></li>
-    <li>AAC LC - using the <a href="http://www.audiocoding.com/">faac</a>
+    <li><a href="https://xiph.org/vorbis/">Ogg Vorbis</a></li>
+    <li>AAC LC - using the <a href="https://www.audiocoding.com/">faac</a>
         library</li>
     <li>AAC HEv2 -
     using <a href="http://tipok.org.ua/node/17">libaacplus</a> library </li>
@@ -50,10 +50,10 @@ DarkIce can encode in the following formats:
 <br>
 DarkIce can send the encoded stream to the following streaming servers:
 <ul>
-    <li><a href="http://www.shoutcast.com/">ShoutCast</a></li>
-    <li><a href="http://www.icecast.org/">IceCast</a> 1.3.x and 2.x</li>
-    <li><a href="http://developer.apple.com/darwin/projects/streaming/">Darwin
-         Streaming Server</a></li>
+    <li><a href="https://www.shoutcast.com/">ShoutCast</a></li>
+    <li><a href="https://www.icecast.org/">IceCast</a> 1.3.x and 2.x</li>
+    <li><a href="https://macosforge.github.io/dss/">Darwin
+      Streaming Server</a></li>
     <li>archive the encoded audio in files</li>
 </ul>
 <br>
@@ -82,7 +82,7 @@ There is a GTK frontend made by Rafael Diniz, called DarkSnow.
 
 <h2>3. Discussion</h2>
 For questions &amp; feedback on DarkIce, please join the
-<a href="http://www.freelists.org/list/darkice">darkice-list</a>
+<a href="https://www.freelists.org/list/darkice">darkice-list</a>
 mailing list.
 <p>
 Should you find any issues with DarkIce, please submit a bug or feature
@@ -111,7 +111,7 @@ git clone <a href="https://github.com/rafael2k/darkice">https://github.com/rafae
 DarkIce is
 &copy; Copyright <a href="http://tyrell.hu">Tyrell Hungary</a> and Rafael Diniz and &Aacute;kos Mar&oacute;y
  under the
-<a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public Licence version 3</a>.
+<a href="https://www.gnu.org/licenses/gpl-3.0.html">GNU General Public Licence version 3</a>.
 </p>
 <p>
   This page last updated: 04/09/2020.

--- a/website/trunk/htdocs/index.html
+++ b/website/trunk/htdocs/index.html
@@ -1,13 +1,12 @@
 <html>
 <head>
 <title>DarkIce live audio streamer</title>
-<!-- $Id: index.html 478 2010-05-12 20:54:28Z rafael@riseup.net $ -->
 </head>
 
 <body bgcolor="#000000" text="#eeeeee" link="#88ccff" alink="#8888ff" vlink="#8888ff">
 <center>
 <table cellspacing="0" cellpadding="0" border="0" width="450" height="100%">
-<tr valign="bottom"><td colspan="9"><img src="blankheader.gif" alt="" border="0" width="450" height="54"></td></tr> 
+<tr valign="bottom"><td colspan="9"><img src="blankheader.gif" alt="" border="0" width="450" height="54"></td></tr>
 <tr valign="middle">
 <td width="2" bgcolor="#604c8f"><img src="spacer.gif" width="2" alt=""></td>
 <td width="5" bgcolor="#392073"><img src="spacer.gif" width="5" alt=""></td>
@@ -67,7 +66,7 @@ Darkice runs on the following operating systems:
     <li>Solaris</li>
 </ul>
 <br>
-DarkIce initial author is 
+DarkIce initial author is
 <a href="mailto:darkeye@users.sourceforge.net">&Aacute;kos Mar&oacute;y</a>
 <br>
 DarkIce current author and maintainer is <a href="mailto:rafael@riseup.net">Rafael Diniz. </a>
@@ -75,7 +74,7 @@ DarkIce current author and maintainer is <a href="mailto:rafael@riseup.net">Rafa
 <h2>2. Status</h2>
 DarkIce is considered stable, it has been used since fall 2000 in production 24 hours per day.
 <br>
-The latest version is <b>1.3</b>, check out the
+The latest version is <b>1.4</b>, check out the
 <a href="https://github.com/rafael2k/darkice/blob/master/darkice/trunk/ChangeLog">ChangeLog</a>.
 <br>
 There is a GTK frontend made by Rafael Diniz, called DarkSnow.
@@ -92,16 +91,16 @@ github <a href="https://github.com/rafael2k/darkice/issues">Issues</a> page.
 </p>
 
 <h2>4. Support</h2>
-If you feel that DarkIce is having a good effect on your online streaming radio, feel free to donate some money to allow further development. 
+If you feel that DarkIce is having a good effect on your online streaming radio, feel free to donate some money to allow further development.
 <b>Thank you! Btw, we already received a donation!</b>
 
 <h2>5. Download</h2>
 <br>
 You can download DarkIce releases from the project's
-<a href="https://sourceforge.net/projects/darkice/files/">download page</a>.
+<a href="https://github.com/rafael2k/darkice/releases">releases page</a>.
 <p>
 Download the source tarball
-    <a href="http://sourceforge.net/projects/darkice/files/darkice/1.3/darkice-1.3.tar.gz/download">darkice-1.3.tar.gz</a>
+    <a href="https://github.com/rafael2k/darkice/releases/download/v1.4/darkice-1.4.tar.gz">darkice-1.4.tar.gz</a>
     and compile it.
 </p>
 <p>
@@ -115,7 +114,7 @@ DarkIce is
 <a href="http://www.gnu.org/copyleft/gpl.html">GNU General Public Licence version 3</a>.
 </p>
 <p>
-  This page last updated: 04/08/2016.
+  This page last updated: 04/09/2020.
   </p>
 </td>
 <td width="5" bgcolor="#1d103a"><img src="spacer.gif" width="5" alt=""></td>


### PR DESCRIPTION
* Update website for release 1.4.
* Update exxternal links.
* Fix date in ChangeLog entry for release 1.4.
* Expand ChangeLog with more details about changes for 1.4 from git log.

Relates: #157 