### PR TITLE
Fix the example configuration, so it works with Icecast2

### DIFF
--- a/darkice/trunk/darkice.cfg
+++ b/darkice/trunk/darkice.cfg
@@ -26,7 +26,9 @@ bitrate         = 96        # bitrate of the stream sent to the server
 server          = yp.yourserver.com
                             # host name of the server
 port            = 8000      # port of the IceCast2 server, usually 8000
-password        = hackme    # source password to the IceCast2 server
+# source password to the IceCast2 server
+password        = hackme
+# there must not be a comment following the password
 mountPoint      = sample96  # mount point of this stream on the IceCast2 server
 name            = DarkIce trial
                             # name of the stream


### PR DESCRIPTION
I ran into this issue: There must not be a comment behind the password.
And several other people reported this to be a problem in this close issue: https://github.com/rafael2k/darkice/issues/154#
Time to fix it. I consider this a bug in documentation.