### PR TITLE
Allow Icecast2 username to be set

### DIFF
--- a/darkice/trunk/src/CastSink.cpp
+++ b/darkice/trunk/src/CastSink.cpp
@@ -56,6 +56,7 @@ static const char fileid[] = "$Id$";
 void
 CastSink :: init (  TcpSocket             * socket,
                     Sink                  * streamDump,
+                    const char            * username,
                     const char            * password,
                     unsigned int            bitRate,
                     const char            * name,
@@ -67,6 +68,7 @@ CastSink :: init (  TcpSocket             * socket,
     this->socket         = socket;
     this->streamDump     = streamDump;
     this->password       = password       ? Util::strDup( password) : 0;
+    this->username       = username       ? Util::strDup( username) : 0;
     this->bitRate        = bitRate;
     this->name           = name           ? Util::strDup( name)     : 0;
     this->url            = url            ? Util::strDup( url)      : 0;

--- a/darkice/trunk/src/CastSink.h
+++ b/darkice/trunk/src/CastSink.h
@@ -112,6 +112,7 @@ class CastSink : public Sink, public virtual Reporter
          *  Initalize the object.
          *
          *  @param socket socket connection to the server.
+         *  @param username username to the server.
          *  @param password password to the server.
          *  @param name name of the stream.
          *  @param url URL associated with the stream.
@@ -205,14 +206,14 @@ class CastSink : public Sink, public virtual Reporter
          */
         inline
         CastSink (  TcpSocket         * socket,
+                    const char        * username,
                     const char        * password,
                     unsigned int        bitRate,
                     const char        * name           = 0,
                     const char        * url            = 0,
                     const char        * genre          = 0,
                     bool                isPublic       = false,
-                    Sink              * streamDump     = 0,
-                    const char        * username       = "source")
+                    Sink              * streamDump     = 0 )
                                                         throw ( Exception )
         {
             init( socket,
@@ -237,13 +238,13 @@ class CastSink : public Sink, public virtual Reporter
         {
             init( cs.socket.get(),
                   cs.streamDump.get(),
+                  cs.username,
                   cs.password,
                   cs.bitRate,
                   cs.name,
                   cs.url,
                   cs.genre,
-                  cs.isPublic,
-                  cs.username );
+                  cs.isPublic );
         }
 
         /**
@@ -272,13 +273,13 @@ class CastSink : public Sink, public virtual Reporter
                 Sink::operator=( cs );
                 init( cs.socket.get(),
                       cs.streamDump.get(),
+                      cs.username,
                       cs.password,
                       cs.bitRate,
                       cs.name,
                       cs.url,
                       cs.genre,
-                      cs.isPublic,
-                      cs.username );
+                      cs.isPublic );
             }
             return *this;
         }

--- a/darkice/trunk/src/CastSink.h
+++ b/darkice/trunk/src/CastSink.h
@@ -74,6 +74,11 @@ class CastSink : public Sink, public virtual Reporter
         Ref<Sink>           streamDump;
 
         /**
+         *  username to the server.
+         */
+        char              * username;
+
+        /**
          *  Password to the server.
          */
         char              * password;
@@ -118,6 +123,7 @@ class CastSink : public Sink, public virtual Reporter
         void
         init (  TcpSocket             * socket,
                 Sink                  * streamDump,
+                const char            * username,
                 const char            * password,
                 unsigned int            bitRate,
                 const char            * name,
@@ -193,6 +199,7 @@ class CastSink : public Sink, public virtual Reporter
          *  @param bitRate bitrate of the stream (e.g. mp3 bitrate).
          *  @param isPublic is the stream public?
          *  @param streamDump a Sink to dump the streamed binary data to
+         *  @param username username to the server.
          *
          *  @exception Exception
          */
@@ -204,11 +211,13 @@ class CastSink : public Sink, public virtual Reporter
                     const char        * url            = 0,
                     const char        * genre          = 0,
                     bool                isPublic       = false,
-                    Sink              * streamDump     = 0)
+                    Sink              * streamDump     = 0,
+                    const char        * username       = "source")
                                                         throw ( Exception )
         {
             init( socket,
                   streamDump,
+                  username,
                   password,
                   bitRate,
                   name,
@@ -233,7 +242,8 @@ class CastSink : public Sink, public virtual Reporter
                   cs.name,
                   cs.url,
                   cs.genre,
-                  cs.isPublic );
+                  cs.isPublic,
+                  cs.username );
         }
 
         /**
@@ -267,7 +277,8 @@ class CastSink : public Sink, public virtual Reporter
                       cs.name,
                       cs.url,
                       cs.genre,
-                      cs.isPublic );
+                      cs.isPublic,
+                      cs.username );
             }
             return *this;
         }
@@ -374,6 +385,18 @@ class CastSink : public Sink, public virtual Reporter
 
             return getSink()->close();
         }
+
+        /**
+         *  Get the username to the server.
+         *
+         *  @return the username to the server.
+         */
+        inline const char *
+        getUsername ( void ) const                  throw ()
+        {
+            return username;
+        }
+
 
         /**
          *  Get the password to the server.

--- a/darkice/trunk/src/DarkIce.cpp
+++ b/darkice/trunk/src/DarkIce.cpp
@@ -537,6 +537,8 @@ DarkIce :: configIceCast2 (  const Config      & config,
         str         = cs->getForSure( "port", " missing in section ", stream);
         port        = Util::strToL( str);
         password    = cs->getForSure("password"," missing in section ",stream);
+        username    = cs->get("username", stream);
+        username    = (username != NULL) ? username : "source";
         mountPoint  = cs->getForSure( "mountPoint",
                                       " missing in section ",
                                       stream);
@@ -589,6 +591,7 @@ DarkIce :: configIceCast2 (  const Config      & config,
         // streaming related stuff
         audioOuts[u].socket = new TcpSocket( server, port);
         audioOuts[u].server = new IceCast2( audioOuts[u].socket.get(),
+                                            username,
                                             password,
                                             mountPoint,
                                             format,

--- a/darkice/trunk/src/DarkIce.cpp
+++ b/darkice/trunk/src/DarkIce.cpp
@@ -457,6 +457,7 @@ DarkIce :: configIceCast2 (  const Config      & config,
         double                      quality         = 0.0;
         const char                * server          = 0;
         unsigned int                port            = 0;
+        const char                * username        = 0;
         const char                * password        = 0;
         const char                * mountPoint      = 0;
         const char                * name            = 0;
@@ -537,7 +538,7 @@ DarkIce :: configIceCast2 (  const Config      & config,
         str         = cs->getForSure( "port", " missing in section ", stream);
         port        = Util::strToL( str);
         password    = cs->getForSure("password"," missing in section ",stream);
-        username    = cs->get("username", stream);
+        username    = cs->get("username");
         username    = (username != NULL) ? username : "source";
         mountPoint  = cs->getForSure( "mountPoint",
                                       " missing in section ",

--- a/darkice/trunk/src/FileCast.h
+++ b/darkice/trunk/src/FileCast.h
@@ -131,7 +131,7 @@ class FileCast : public CastSink
         inline
         FileCast (  FileSink          * targetFile )
                                                         throw ( Exception )
-                : CastSink( 0, 0, 0)
+                : CastSink( 0, 0, 0, 0)
         {
             init( targetFile );
         }

--- a/darkice/trunk/src/IceCast.h
+++ b/darkice/trunk/src/IceCast.h
@@ -156,6 +156,7 @@ class IceCast : public CastSink
                     Sink              * streamDump     = 0 )
                                                         throw ( Exception )
               : CastSink( socket,
+                          NULL,
                           password,
                           bitRate,
                           name,

--- a/darkice/trunk/src/IceCast2.cpp
+++ b/darkice/trunk/src/IceCast2.cpp
@@ -180,6 +180,8 @@ IceCast2 :: sendLogin ( void )                           throw ( Exception )
     {
         // send source:<password> encoded as base64
         const char  * username = getUsername();
+        if(username == NULL)
+            username = "source";
         const char  * pwd    = getPassword();
         char        * tmp    = new char[Util::strLen(username) + 1 +
                                         Util::strLen(pwd) + 1];

--- a/darkice/trunk/src/IceCast2.cpp
+++ b/darkice/trunk/src/IceCast2.cpp
@@ -179,11 +179,12 @@ IceCast2 :: sendLogin ( void )                           throw ( Exception )
     sink->write( str, strlen(str));
     {
         // send source:<password> encoded as base64
-        const char  * source = "source:";
+        const char  * username = getUsername();
         const char  * pwd    = getPassword();
-        char        * tmp    = new char[Util::strLen(source) +
+        char        * tmp    = new char[Util::strLen(username) + 1 +
                                         Util::strLen(pwd) + 1];
-        Util::strCpy( tmp, source);
+        Util::strCpy( tmp, username);
+        Util::strCat( tmp, ":");
         Util::strCat( tmp, pwd);
         char  * base64 = Util::base64Encode( tmp);
         delete[] tmp;

--- a/darkice/trunk/src/IceCast2.h
+++ b/darkice/trunk/src/IceCast2.h
@@ -135,6 +135,7 @@ class IceCast2 : public CastSink
          *  Constructor.
          *
          *  @param socket socket connection to the server.
+         *  @param username to be passed to the server
          *  @param password password to the server.
          *  @param mountPoint mount point of the stream on the server.
          *  @param format the format of the stream.
@@ -152,6 +153,7 @@ class IceCast2 : public CastSink
          */
         inline
         IceCast2 (  TcpSocket         * socket,
+                    const char        * username,
                     const char        * password,
                     const char        * mountPoint,
                     StreamFormat        format,
@@ -164,6 +166,7 @@ class IceCast2 : public CastSink
                     Sink              * streamDump     = 0 )
                                                         throw ( Exception )
               : CastSink( socket,
+                          username,
                           password,
                           bitRate,
                           name,

--- a/darkice/trunk/src/ShoutCast.h
+++ b/darkice/trunk/src/ShoutCast.h
@@ -165,6 +165,7 @@ class ShoutCast : public CastSink
                     Sink              * streamDump     = 0 )
                                                         throw ( Exception )
               : CastSink( socket,
+                          NULL,
                           password,
                           bitRate,
                           name,


### PR DESCRIPTION
Darkice hard-codes the username "source" for all Icecast2 connections. This PR allows a "username" property to be specified to allow connection to servers that do not use the default username.
