### PR TITLE
fix: exit gracefully when Exception caught

### DIFF
--- a/darkice/trunk/src/AlsaDspSource.cpp
+++ b/darkice/trunk/src/AlsaDspSource.cpp
@@ -262,13 +262,17 @@ AlsaDspSource :: read (    void          * buf,
     } while (ret == -EAGAIN);
 
     if ( ret == -EBADFD ) {
-        throw Exception(__FILE__, __LINE__,
-                        "ALSA/PCM device is in a bad state: ",
-                        std::to_string(snd_pcm_state(captureHandle)).c_str());
+        Exception e = Exception(__FILE__, __LINE__,
+                                "ALSA/PCM device is in a bad state: ",
+                                std::to_string(snd_pcm_state(captureHandle)).c_str());
+        close();
+        throw e;
     }
 
     if ( ret < 0 ) {
-        throw Exception(__FILE__, __LINE__, snd_strerror(ret));
+        Exception e = Exception(__FILE__, __LINE__, snd_strerror(ret));
+        close();
+        throw e;
     }
 
     running = true;

--- a/darkice/trunk/src/AlsaDspSource.cpp
+++ b/darkice/trunk/src/AlsaDspSource.cpp
@@ -261,6 +261,12 @@ AlsaDspSource :: read (    void          * buf,
         }
     } while (ret == -EAGAIN);
 
+    if ( ret == -EBADFD ) {
+        throw Exception(__FILE__, __LINE__,
+                        "ALSA/PCM device is in a bad state: ",
+                        std::to_string(snd_pcm_state(captureHandle)).c_str());
+    }
+
     if ( ret < 0 ) {
         throw Exception(__FILE__, __LINE__, snd_strerror(ret));
     }

--- a/darkice/trunk/src/AlsaDspSource.h
+++ b/darkice/trunk/src/AlsaDspSource.h
@@ -47,6 +47,7 @@
 
 #include "Reporter.h"
 #include "AudioSource.h"
+#include <string>
 
 #ifdef HAVE_ALSA_LIB
 #include <alsa/asoundlib.h>

--- a/darkice/trunk/src/main.cpp
+++ b/darkice/trunk/src/main.cpp
@@ -160,6 +160,7 @@ main (
 
     } catch ( Exception   & e ) {
         std::cout << "DarkIce: " << e << std::endl << std::flush;
+        _exit(1);
     }
 
     return res;


### PR DESCRIPTION
Closes #178

This change does two things.

1) Improve top-level Exception handler

When an Exception is thrown by AlsaDspSource (and likely other implementations of AudioSource), the application's main() catches the Exception, prints the Exception to stdout, proceeds past the catch block, and returns. We normally expect a process to terminate when main() returns, but instead, the process hangs, not processing audio from the failed source, not doing any useful work. This behavior is confusing to the user.

The reason the process doesn't exit is that all of the process's threads need to be join or terminated, to trigger a clean process exit. However, when an Exception bubbles all the way up to main(), a clean exit isn't certain.

This change properly carries out a "dirty" process termination. The Exception handler in main() calls `_exit()`. From `man _exit`:
```text
_exit() terminates the calling process "immediately". Any open file descriptors belonging to the
process are closed.
...
The function _exit() is like exit(3), but does not call any functions registered with  atexit(3)  or
on_exit(3).  Open stdio(3) streams are not flushed.  On the other hand, _exit() does close open file
descriptors...
```

As a side note, the specific need to terminate all threads, in order to honor the requirement to terminate the process "immediately" was rectified in glibc 2.3, [which was released in 2002](https://sourceware.org/git/?p=glibc.git;a=tag;h=fece652bc1e6b119904aa75d7fdded4a1fe9462d). Again, from `man _exit`:
```text
Since glibc 2.3, the wrapper function invokes exit_group(2), in order to terminate all of the
threads in a process. (The raw _exit() system call terminates only the calling thread.)
```

2) Improve ALSA Exception message

Some ALSA drivers (and/or some audio hardware) occasionally misbehaves, causing `snd_pcm_readi()` to return `EBADFD` meaning "the device is in a bad state" or "PCM is not in the right state". In my case, the invalid state is, indeed, an invalid state; the state returned by `snd_pcm_state()` is `19`, which has no corresponding value in the ALSA PCM state enum `_snd_pcm_state`, which ranges `0~8` in ALSA 1.2.4.

This change improves the Exception message in this case, to correctly indicate to the user which "bad state" triggered the error. This may indicate a valid, recoverable state, in which case, further investigation could lead to further improvements. (In my case, it indicates an invalid state, hence the first point.)