### PR TITLE
fix: include cstring lib when building with faac

### DIFF
--- a/darkice/trunk/src/FaacEncoder.h
+++ b/darkice/trunk/src/FaacEncoder.h
@@ -42,6 +42,7 @@
 
 #ifdef HAVE_FAAC_LIB
 #include <faac.h>
+#include <cstring>
 #else
 #error configure with faac
 #endif


### PR DESCRIPTION
fixes #193 