### PR TITLE
fix fileAddDate with SIGUSR1

### DIFF
--- a/darkice/trunk/src/DarkIce.cpp
+++ b/darkice/trunk/src/DarkIce.cpp
@@ -345,26 +345,15 @@ DarkIce :: configIceCast (  const Config      & config,
 
         // check for and create the local dump file if needed
         if ( localDumpName != 0 ) {
-            if ( fileAddDate ) {
-                if (fileDateFormat == 0) {
-                    localDumpName = Util::fileAddDate(localDumpName);
-                }
-                else {
-                    localDumpName = Util::fileAddDate(  localDumpName,
-                                                        fileDateFormat );
-                }
-            }
+            localDumpFile = new FileSink( stream, localDumpName,
+                                          fileAddDate, fileDateFormat );
 
-            localDumpFile = new FileSink( stream, localDumpName);
             if ( !localDumpFile->exists() ) {
                 if ( !localDumpFile->create() ) {
                     reportEvent( 1, "can't create local dump file",
                                     localDumpName);
                     localDumpFile = 0;
                 }
-            }
-            if ( fileAddDate ) {
-                delete[] localDumpName;
             }
         }
         // streaming related stuff
@@ -575,26 +564,14 @@ DarkIce :: configIceCast2 (  const Config      & config,
 
         // check for and create the local dump file if needed
         if ( localDumpName != 0 ) {
-            if ( fileAddDate ) {
-                if (fileDateFormat == 0) {
-                    localDumpName = Util::fileAddDate(localDumpName);
-                }
-                else {
-                    localDumpName = Util::fileAddDate(  localDumpName,
-                                                        fileDateFormat );
-                }
-            }
-
-            localDumpFile = new FileSink( stream, localDumpName);
+            localDumpFile = new FileSink( stream, localDumpName,
+                                          fileAddDate, fileDateFormat );
             if ( !localDumpFile->exists() ) {
                 if ( !localDumpFile->create() ) {
                     reportEvent( 1, "can't create local dump file",
                                     localDumpName);
                     localDumpFile = 0;
                 }
-            }
-            if ( fileAddDate ) {
-                delete[] localDumpName;
             }
         }
 
@@ -902,26 +879,15 @@ DarkIce :: configShoutCast (    const Config      & config,
 
         // check for and create the local dump file if needed
         if ( localDumpName != 0 ) {
-            if ( fileAddDate ) {
-                if (fileDateFormat == 0) {
-                    localDumpName = Util::fileAddDate(localDumpName);
-                }
-                else {
-                    localDumpName = Util::fileAddDate(  localDumpName,
-                                                        fileDateFormat );
-                }
-            }
+            localDumpFile = new FileSink( stream, localDumpName,
+                                          fileAddDate, fileDateFormat );
 
-            localDumpFile = new FileSink( stream, localDumpName);
             if ( !localDumpFile->exists() ) {
                 if ( !localDumpFile->create() ) {
                     reportEvent( 1, "can't create local dump file",
                                     localDumpName);
                     localDumpFile = 0;
                 }
-            }
-            if ( fileAddDate ) {
-                delete[] localDumpName;
             }
         }
 
@@ -1074,17 +1040,9 @@ DarkIce :: configFileCast (  const Config      & config )
         // go on and create the things
 
         // the underlying file
-        if ( fileAddDate ) {
-            if (fileDateFormat == 0) {
-                targetFileName = Util::fileAddDate( targetFileName);
-            }
-            else {
-                targetFileName = Util::fileAddDate( targetFileName,
-                                                    fileDateFormat );
-            }
-        }
+        FileSink  * targetFile = new FileSink( stream, targetFileName,
+                                               fileAddDate, fileDateFormat );
 
-        FileSink  * targetFile = new FileSink( stream, targetFileName);
         if ( !targetFile->exists() ) {
             if ( !targetFile->create() ) {
                 throw Exception( __FILE__, __LINE__,

--- a/darkice/trunk/src/FileSink.h
+++ b/darkice/trunk/src/FileSink.h
@@ -75,11 +75,15 @@ class FileSink : public Sink, public virtual Reporter
          *  @param configName the name of the configuration related to
          *         this file sink. something like "file-0" or "file-2".
          *  @param name name of the file to be represented by the object.
+         *  @param addDate add a date to the filename.
+         *  @param fileDateFormat optional date format of the added date
          *  @exception Exception
          */
         void
         init (  const char    * configName,
-                const char    * name )              ;
+                const char    * name,
+                const bool      addDate,
+                const char    * fileDateFormat );
 
         /**
          *  De-initialize the object.
@@ -108,6 +112,22 @@ class FileSink : public Sink, public virtual Reporter
         int         fileDescriptor;
 
         /**
+         *  Actual filename f.e. when using fileAddDate.
+         */
+        char      * fileNameActual;
+
+        /**
+         *  Whether a date is added to the filename or not.
+         */
+        bool        addDate;
+
+        /**
+         *  Date format of the added date.
+         */
+        char      * fileDateFormat;
+
+        /**
+
          *  Default constructor. Always throws an Exception.
          *  
          *  @exception Exception
@@ -127,13 +147,17 @@ class FileSink : public Sink, public virtual Reporter
          *  @param configName the name of the configuration related to
          *         this file sink. something like "file-0" or "file-2".
          *  @param name name of the file to be represented by the object.
+         *  @param addDate add a date to the filename.
+         *  @param fileDateFormat optional date format of the added date
          *  @exception Exception
          */
         inline
         FileSink(   const char        * configName,
-                    const char        * name )      
+                    const char        * name,
+                    const bool          addDate,
+                    const char        * fileDateFormat )
         {
-            init( configName, name);
+            init( configName, name, addDate, fileDateFormat );
         }
 
         /**


### PR DESCRIPTION
If fileAddDate = yes is set and if we send darkice the USR1 signal, it should write the data into the file with the up-to-date date, not override the initial one.

My patch is based on the patch from neingeist.

This fixes https://github.com/rafael2k/darkice/issues/141