### PR TITLE
Fixing null free() causing assertion failures with pulse (#202)

### DIFF
--- a/darkice/src/PulseAudioDspSource.cpp
+++ b/darkice/src/PulseAudioDspSource.cpp
@@ -179,12 +179,10 @@ bool
 PulseAudioDspSource :: canRead ( unsigned int    sec,
                            unsigned int    usec )    
 {
-  
-  /** Strange have to remove this, need to investigate... */
-  /*  if ( !isOpen() ) {
+
+    if ( !isOpen() ) {
         return false;
-      }
-  */
+    }
 
     if (running == 0) {
       char         client_name[255];
@@ -232,6 +230,7 @@ PulseAudioDspSource :: close ( void )
 
     pa_simple_free(s);
     running = 0;
+    s = NULL;
 }
 
 #endif // HAVE_PULSEAUDIO_LIB

--- a/darkice/src/PulseAudioDspSource.h
+++ b/darkice/src/PulseAudioDspSource.h
@@ -203,7 +203,7 @@ class PulseAudioDspSource : public AudioSource, public virtual Reporter
         inline virtual bool
         isOpen ( void ) const                           throw ()
         {
-            return s==NULL;
+            return s != NULL;
         }
 
         /**
@@ -450,7 +450,7 @@ class PulseAudioDspSource : public AudioSource, public virtual Reporter
         inline virtual bool
         isOpen ( void ) const                           throw ()
         {
-            return s==NULL;
+            return s != NULL;
         }
 
         /**


### PR DESCRIPTION
Looks like the pulse client isOpen logic is flipped, causing all sorts of weird bugs? Not completely familiar with the internals of this project so feedback appreciated.